### PR TITLE
[#9] 폴더 findAll Reponse 추가, 부모 리스트 조회 Response 역순

### DIFF
--- a/src/main/kotlin/com/yapp/web2/domain/folder/entity/Folder.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/folder/entity/Folder.kt
@@ -146,7 +146,8 @@ class Folder(
         class RootFolder(
             var id: Long, // 폴더 ID
             var children: MutableList<Long>? = mutableListOf(),
-            var data: RootFolderData
+            var data: RootFolderData,
+            val isExpanded: Boolean = false
         )
 
         class RootFolderData(

--- a/src/main/kotlin/com/yapp/web2/domain/folder/service/FolderService.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/folder/service/FolderService.kt
@@ -245,8 +245,9 @@ class FolderService(
             }
             parentFolder = parentFolder.parentFolder
         }
+        childList.reverse()
+
         return childList
     }
-
 
 }

--- a/src/main/kotlin/com/yapp/web2/domain/folder/service/FolderService.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/folder/service/FolderService.kt
@@ -90,8 +90,6 @@ class FolderService(
             nextParentFolder = folderRepository.findById(nextParentId).get()
         }
 
-        // (moveFolder.parentFolder == null && nextParentId
-
         /* 최상위 -> 최상위 OR 상위 -> 상위(동일한 부모) */
         if (isMoveTopFolderToTopFolder(moveFolder, nextParentId)
             || isMoveFolderToFolderWithEqualParent(moveFolder, nextParentFolder)


### PR DESCRIPTION
- 폴더 조회(findAll) Reponse에 isExpanded 추가
  - DB에서 관리하지는 않고 단순히 프론트쪽으로 false 값만 전달합니다.
  - 사용자가 페이지 열었는지 이력 확인하는 용도(?)
- 부모 리스트 조회 API 역순으로 수정