### PR TITLE
[#10] bookmark save할 때, 기존 api 롤백 & extension version check 기능 추가

### DIFF
--- a/src/main/kotlin/com/yapp/web2/domain/account/controller/AccountController.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/account/controller/AccountController.kt
@@ -87,4 +87,10 @@ class AccountController(
         accountService.changeBackgroundColor(token, changeUrl)
         return ResponseEntity.status(HttpStatus.OK).body(Message.SUCCESS)
     }
+
+
+    @GetMapping("/{extensionVersion}")
+    fun checkExtensionVersion(@PathVariable extensionVersion: String): ResponseEntity<String> {
+        return ResponseEntity.status(HttpStatus.OK).body(accountService.checkExtension(extensionVersion))
+    }
 }

--- a/src/main/kotlin/com/yapp/web2/domain/account/service/AccountService.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/account/service/AccountService.kt
@@ -10,6 +10,7 @@ import com.yapp.web2.exception.BusinessException
 import com.yapp.web2.exception.custom.ExistNameException
 import com.yapp.web2.exception.custom.ImageNotFoundException
 import com.yapp.web2.util.Message
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.web.multipart.MultipartFile
 import javax.transaction.Transactional
@@ -21,6 +22,9 @@ class AccountService(
     private val jwtProvider: JwtProvider,
     private val s3Uploader: S3Uploader
 ) {
+
+    @Value("\${extension.version}")
+    private lateinit var extensionVersion: String
 
     companion object {
         private const val DIR_NAME = "static"
@@ -118,5 +122,10 @@ class AccountService(
     fun changeBackgroundColor(token: String, changeUrl: String) {
         val account = jwtProvider.getAccountFromToken(token)
         account.backgroundColor = changeUrl
+    }
+
+    fun checkExtension(userVersion: String): String {
+        return if(userVersion == extensionVersion) Message.LATEST_EXTENSION_VERSION
+        else Message.OLD_EXTENSION_VERSION
     }
 }

--- a/src/main/kotlin/com/yapp/web2/domain/bookmark/controller/BookmarkController.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/bookmark/controller/BookmarkController.kt
@@ -23,8 +23,19 @@ class BookmarkController(
         return ResponseEntity.status(HttpStatus.OK).body(Message.CLICK)
     }
 
+    @PostMapping("/{folderId}")
+    fun createBookmark(
+        request: HttpServletRequest,
+        @PathVariable @ApiParam(value = "북마크를 지정할 폴더 ID", example = "12", required = true) folderId: Long,
+        @RequestBody @ApiParam(value = "북마크 생성 정보", required = true) bookmark: Bookmark.AddBookmarkDto
+    ): ResponseEntity<String> {
+        val token = ControllerUtil.extractAccessToken(request)
+        bookmarkService.addBookmark(token, folderId, bookmark)
+        return ResponseEntity.status(HttpStatus.OK).body(Message.SAVED)
+    }
+
     @ApiOperation(value = "북마크 생성 API")
-    @PostMapping()
+    @PostMapping
     fun createBookmark(
         request: HttpServletRequest,
         @RequestParam @ApiParam(value = "북마크를 지정할 폴더 ID", example = "12", required = true) folderId: Long?,

--- a/src/main/kotlin/com/yapp/web2/util/Message.kt
+++ b/src/main/kotlin/com/yapp/web2/util/Message.kt
@@ -37,5 +37,8 @@ class Message {
         var OBJECT_NOT_FOUND = "개체가 존재하지 않습니다"
 
         var NOTIFICATION_MESSAGE = "깜빡한 도토리가 있지 않나요?"
+
+        var OLD_EXTENSION_VERSION = "익스텐션 버전이 오래되었습니다!"
+        var LATEST_EXTENSION_VERSION = "최신 버전입니다."
     }
 }


### PR DESCRIPTION
### 개요
- bookmark save 기존 버전 api 추가
- extension version check 기능 추가

### 작업사항
- extension 버전이 다르더라도 bookmark를 저장할 수 있도록, 기존 버전의 api를 남겨놨습니다.
- extension version이 맞지 않을 때, 출력 메시지를 보내는 로직 추가했습니다.
