### PR TITLE
[#140] 패스워드 유효성 검증 로직 & docker-compose, Spring Boot logback 로깅 설명

### DIFF
--- a/src/main/kotlin/com/yapp/web2/domain/account/entity/AccountRequestDto.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/account/entity/AccountRequestDto.kt
@@ -18,7 +18,7 @@ class AccountRequestDto {
 
         @ApiModelProperty(value = "비밀번호", required = true, example = "!1234567")
         @field: NotBlank(message = "비밀번호를 입력해주세요")
-//        @field: CustomPassword
+        @field: CustomPassword
         val password: String,
 
         @ApiModelProperty(value = "FCM 토큰", required = true, example = "dOOUnnp-iBs:APA91bF1i7mobIF7kEhi3aVlFuv6A5--P1S...")

--- a/src/main/kotlin/com/yapp/web2/domain/account/entity/AccountRequestDto.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/account/entity/AccountRequestDto.kt
@@ -41,7 +41,7 @@ class AccountRequestDto {
         val email: String,
 
         @ApiModelProperty(value = "비밀번호", required = true, example = "!1234567")
-//        @field: CustomPassword
+        @field: CustomPassword
         val password: String
     )
 
@@ -56,12 +56,12 @@ class AccountRequestDto {
     class PasswordChangeRequest(
         @ApiModelProperty(value = "기존 비밀번호", required = true, example = "1234567!")
         @field: NotBlank(message = "기존 비밀번호를 입력해주세요")
-//        @field: CustomPassword
+        @field: CustomPassword
         val currentPassword: String,
 
         @ApiModelProperty(value = "새 비밀번호", required = true, example = "12345678!")
         @field: NotBlank(message = "새 비밀번호를 입력해주세요")
-//        @field: CustomPassword
+        @field: CustomPassword
         val newPassword: String
     )
 


### PR DESCRIPTION
### 개요
- 패스워드 유효성 검증 로직 추가

### 작업사항
- 이전에 상용서버에 패스워드 유효성 검증 제거한 로직 롤백

### 기타
> 추가적으로 docker-compose, spring boot logback logging 설정은 다음과 같습니다.
- Dockerfile에 VOLUME 키워드로 컨테이너에서 로그로 남길 디렉토리 설정
```java
// Dockerfile-dev, Dockerfile-prod
VOLUME ["/var/log"]
```
- log를 남기는 파일 설정은 컨테이너 로그 설정한 경로 기준으로 설정
```java
// spring-logback.xml
<property name="LOG_DIR_SERVER" value="/var/log"/>
<property name="LOG_FILE" value="logfile.log"/>

...
<file>${LOG_FILE_PROD}</file>
...
```

- 다음으로 docker-compose.yaml 파일에서 volumes 설정
```java
// docker-compose.yaml 
...

  dotoriham:

    ...
    
    volumes:
      - /home/ec2-user/log:/var/log // 호스트 경로:컨테이너 경로
```
- 위 설정을 하면 EC2 서버 내의 /home/ec2-user/log 경로에 로그파일이 기록이 됩니다.(아직 손봐야 할 부분이 많긴 합니다..;)