### PR TITLE
[#132] 공유

### DIFF
--- a/src/main/kotlin/com/yapp/web2/domain/bookmark/repository/BookmarkRepository.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/bookmark/repository/BookmarkRepository.kt
@@ -37,14 +37,14 @@ interface BookmarkRepository : MongoRepository<Bookmark, String> {
     fun findAllBookmarkByFcmToken(fcmToken: String): List<Bookmark>
 
     @Query(value = "{\$and: [{folderId: {\$in: ?1}}, {deleted: false}, {remindList: {\$elemMatch: {userId : ?0}}}]}")
-    fun findRemindBookmarkInFolder(userId: Long, folderIdList: List<Long>): List<Bookmark>
+    fun findRemindBookmarkInFolder(userId: Long, folderIdList: List<Long>, pageable: Pageable): Page<Bookmark>
 
     @Query(value = "{\$or: [{folderId: {\$in: ?1}}, {userId: ?0}]}")
-    fun findAllBookmark(userId: Long, folderIdList: List<Long>): List<Bookmark>
+    fun findAllBookmark(userId: Long, folderIdList: List<Long>, pageable: Pageable): Page<Bookmark>
 
     @Query(value = "{\$and: [{remindList: {\$elemMatch: {userId: ?0}}}, {remindList: {\$elemMatch: {remindTime: ?1}}}]}")
     fun findTodayRemindBookmark(userId: Long, today: String): List<Bookmark>
 
     @Query(value = "{ 'remindList': { \$elemMatch: { 'userId' : ?0 } } }")
-    fun findRemindBookmark(userId: Long): List<Bookmark>
+    fun findRemindBookmark(userId: Long, pageable: Pageable): Page<Bookmark>
 }

--- a/src/main/kotlin/com/yapp/web2/domain/bookmark/service/BookmarkPageService.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/bookmark/service/BookmarkPageService.kt
@@ -6,7 +6,6 @@ import com.yapp.web2.domain.bookmark.repository.BookmarkRepository
 import com.yapp.web2.domain.folder.entity.Folder
 import com.yapp.web2.security.jwt.JwtProvider
 import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -28,11 +27,7 @@ class BookmarkPageService(
         val userId = jwtProvider.getIdFromToken(token)
 
         return when (remind) {
-            true -> {
-                val bookmarkList =
-                    bookmarkRepository.findRemindBookmarkInFolder(userId, folderIdList = mutableListOf(folderId))
-                PageImpl(bookmarkList, pageable, bookmarkList.size.toLong())
-            }
+            true -> bookmarkRepository.findRemindBookmarkInFolder(userId, folderIdList = mutableListOf(folderId), pageable)
             false -> bookmarkRepository.findAllByFolderIdAndDeletedIsFalse(folderId, pageable)
         }
     }
@@ -52,19 +47,15 @@ class BookmarkPageService(
         val account = jwtProvider.getAccountFromToken(token)
 
         return when (remind) {
-            true -> {
-                val bookmarkList =
-                    bookmarkRepository.findRemindBookmark(account.id!!)
-                PageImpl(bookmarkList, pageable, bookmarkList.size.toLong())
-            }
+            true -> bookmarkRepository.findRemindBookmark(account.id!!, pageable)
+
             false -> {
                 val folderIdList = mutableListOf<Long>()
 
                 for (af in account.accountFolderList)
                     folderIdList.addAll(getAllLowerFolderId(af.folder))
 
-                val bookmarkList = bookmarkRepository.findAllBookmark(account.id!!, folderIdList)
-                PageImpl(bookmarkList, pageable, bookmarkList.size.toLong())
+                bookmarkRepository.findAllBookmark(account.id!!, folderIdList, pageable)
             }
         }
     }
@@ -88,6 +79,4 @@ class BookmarkPageService(
             bookmarkRepository.findTodayRemindBookmark(idFromToken, yesterday)
         )
     }
-
-
 }

--- a/src/main/kotlin/com/yapp/web2/domain/folder/entity/AccountFolder.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/folder/entity/AccountFolder.kt
@@ -1,13 +1,7 @@
 package com.yapp.web2.domain.folder.entity
 
 import com.yapp.web2.domain.account.entity.Account
-import javax.persistence.Entity
-import javax.persistence.GeneratedValue
-import javax.persistence.Id
-import javax.persistence.JoinColumn
-import javax.persistence.ManyToOne
-import javax.persistence.FetchType
-import javax.persistence.GenerationType
+import javax.persistence.*
 
 @Entity
 class AccountFolder(
@@ -29,5 +23,6 @@ class AccountFolder(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long? = null
 
+    @Enumerated(EnumType.STRING)
     var authority: Authority = Authority.NONE
 }


### PR DESCRIPTION
### 개요
- 도토리 조회시 필터하는 부분이 작동하지 않았던 문제 해결
- Authority Enum을 String으로 저장하도록 변경

### 작업사항
- BookmarkRepository에서 pageable 적용한 데이터를 받아올 수 있도록 파라메터 추가 및 return 형식을 Page로 변경
- AccountFolder에 Authority가 데이터베이스에서 String으로 보일 수 있도록 변환
- 대신, Product 서버에 적용할 때, AccountFolder에서 Authority의 타입을 변경한 후에 작업해야함.
