### PR TITLE
[#168] 공유 관련 수정

### DIFF
--- a/src/main/kotlin/com/yapp/web2/domain/account/controller/AccountController.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/account/controller/AccountController.kt
@@ -125,11 +125,20 @@ class AccountController(
         return ResponseEntity.status(HttpStatus.OK).body(accountService.checkExtension(extensionVersion))
     }
 
+    @ApiOperation(value = "폴더 토큰을 통하여 공유 폴더에 초대받는 API")
     @GetMapping("/invite/{folderToken}")
-    fun acceptInvitation(request: HttpServletRequest, @PathVariable folderToken: String): ResponseEntity<String> {
+    fun acceptInvitation(request: HttpServletRequest, @ApiParam(value = "폴더 토큰") @PathVariable folderToken: String): ResponseEntity<String> {
         val token = ControllerUtil.extractAccessToken(request)
         accountService.acceptInvitation(token, folderToken)
-        return ResponseEntity.status(HttpStatus.OK).body("good")
+        return ResponseEntity.status(HttpStatus.OK).body(Message.SUCCESS)
+    }
+
+    @ApiOperation(value = "folderId를 통하여 공유 폴더에서 나가는 API")
+    @GetMapping("/exit/{folderId}")
+    fun exitSharedFolder(request: HttpServletRequest, @ApiParam(value = "폴더 아이디") @PathVariable folderId: Long): ResponseEntity<String> {
+        val token = ControllerUtil.extractAccessToken(request)
+        accountService.exitSharedFolder(folderId, token)
+        return ResponseEntity.status(HttpStatus.OK).body(Message.SUCCESS)
     }
 
     @ApiOperation("회원가입 API")

--- a/src/main/kotlin/com/yapp/web2/domain/account/entity/Account.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/account/entity/Account.kt
@@ -2,6 +2,7 @@ package com.yapp.web2.domain.account.entity
 
 import com.yapp.web2.domain.BaseTimeEntity
 import com.yapp.web2.domain.folder.entity.AccountFolder
+import com.yapp.web2.domain.folder.entity.Folder
 import com.yapp.web2.security.jwt.TokenDto
 import io.swagger.annotations.ApiModel
 import io.swagger.annotations.ApiModelProperty
@@ -98,7 +99,7 @@ class Account(
     @Column
     var deleted: Boolean = false
 
-    @OneToMany(mappedBy = "account")
+    @OneToMany(mappedBy = "account", cascade = [CascadeType.ALL])
     var accountFolderList: MutableList<AccountFolder> = mutableListOf()
 
     @ApiModel(description = "소셜로그인 DTO")
@@ -166,11 +167,12 @@ class Account(
         val nickName: String
     )
 
-    fun hasAccountFolder(accountFolder: AccountFolder): Boolean {
-        for (af in this.accountFolderList)
-            if (accountFolder == af) return true
-
-        return false
+    fun removeFolderInAccountFolder(folder: Folder) {
+        for(af in this.accountFolderList)
+            if (af.folder == folder) {
+                accountFolderList.remove(af)
+                return
+            }
     }
 
     fun softDeleteAccount() {

--- a/src/main/kotlin/com/yapp/web2/domain/account/service/AccountService.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/account/service/AccountService.kt
@@ -195,19 +195,31 @@ class AccountService(
         val folderId = jwtProvider.getIdFromToken(folderToken)
         val rootFolder = folderService.findByFolderId(folderId)
 
-        if(rootFolder.rootFolderId != null) throw FolderNotRootException()
+        if (rootFolder.rootFolderId != null) throw FolderNotRootException()
 
         val accountFolder = AccountFolder(account, rootFolder)
         accountFolder.changeAuthority(Authority.INVITEE)
         // account에 굳이 추가하지 않아도 account-folder에 추가가 된다.
         // 왜???
-        if(account.isInsideAccountFolder(accountFolder)) throw AlreadyInvitedException()
+        if (account.isInsideAccountFolder(accountFolder)) throw AlreadyInvitedException()
 //        account.addAccountFolder(accountFolder)
         rootFolder.folders?.add(accountFolder)
     }
 
+
+    fun exitSharedFolder(folderId: Long, token: String) {
+        val account = jwtProvider.getAccountFromToken(token)
+        val folder = folderService.findByFolderId(folderId)
+        var exitFolder = folder.rootFolderId?.let {
+            folderService.findByFolderId(it)
+        } ?: folder
+
+        account.removeFolderInAccountFolder(exitFolder)
+    }
+
     fun signIn(request: AccountRequestDto.SignInRequest): Account.AccountLoginSuccess? {
-        val account = accountRepository.findByEmail(request.email) ?: throw IllegalStateException(Message.NOT_EXIST_EMAIL)
+        val account =
+            accountRepository.findByEmail(request.email) ?: throw IllegalStateException(Message.NOT_EXIST_EMAIL)
 
         if (!passwordEncoder.matches(request.password, account.password)) {
             throw IllegalStateException(Message.USER_PASSWORD_MISMATCH)

--- a/src/main/kotlin/com/yapp/web2/domain/bookmark/BookmarkDto.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/bookmark/BookmarkDto.kt
@@ -1,6 +1,5 @@
 package com.yapp.web2.domain.bookmark
 
-import com.google.common.collect.ImmutableList
 import com.yapp.web2.domain.account.entity.Account
 import com.yapp.web2.domain.bookmark.entity.Bookmark
 import com.yapp.web2.domain.bookmark.entity.BookmarkInterface
@@ -9,7 +8,6 @@ import com.yapp.web2.domain.bookmark.entity.SharedBookmark
 import com.yapp.web2.domain.folder.entity.Folder
 import io.swagger.annotations.ApiModel
 import io.swagger.annotations.ApiModelProperty
-import java.time.LocalDateTime
 import javax.validation.constraints.NotEmpty
 import javax.validation.constraints.NotNull
 
@@ -19,7 +17,7 @@ class BookmarkDto {
         fun addBookmarkDtoToPersonalBookmark(bookmarkDto: AddBookmarkDto, account: Account): BookmarkInterface {
             return PersonalBookmark(
                 account,
-                bookmarkDto.link,
+                bookmarkDto.url,
                 bookmarkDto.title,
                 bookmarkDto.image,
                 bookmarkDto.description,
@@ -28,13 +26,13 @@ class BookmarkDto {
         }
 
         fun addBookmarkDtoToBookmark(bookmarkDto: AddBookmarkDto, account: Account): Bookmark {
-            return Bookmark(account, bookmarkDto.link, bookmarkDto.title, bookmarkDto.image, bookmarkDto.description, bookmarkDto.remind)
+            return Bookmark(account, bookmarkDto.url, bookmarkDto.title, bookmarkDto.image, bookmarkDto.description, bookmarkDto.remind)
         }
 
         fun addBookmarkDtoToSharedBookmark(bookmarkDto: AddBookmarkDto, account: Account, folder: Folder): BookmarkInterface {
             return SharedBookmark(
                 account,
-                bookmarkDto.link,
+                bookmarkDto.url,
                 bookmarkDto.title,
                 bookmarkDto.image,
                 bookmarkDto.description,
@@ -59,7 +57,7 @@ class BookmarkDto {
 
         // TODO: 2021/12/04 RequestParam 데이터 검증
         @ApiModelProperty(value = "북마크 url", required = true, example = "https://www.naver.com")
-        var link: String,
+        var url: String,
 
         @ApiModelProperty(value = "북마크 제목", example = "Bookmark Title")
         var title: String,

--- a/src/main/kotlin/com/yapp/web2/domain/bookmark/controller/SharedBookmarkController.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/bookmark/controller/SharedBookmarkController.kt
@@ -13,7 +13,7 @@ import javax.servlet.http.HttpServletRequest
 import javax.validation.Valid
 
 @RestController
-@RequestMapping("/api/v1/sharedBookmark")
+@RequestMapping("/api/v1/shared")
 class SharedBookmarkController(
     private val sharedBookmarkService: SharedBookmarkService
 ) {

--- a/src/main/kotlin/com/yapp/web2/domain/bookmark/entity/Bookmark.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/bookmark/entity/Bookmark.kt
@@ -85,6 +85,8 @@ class Bookmark(
 
     var remindList = mutableListOf<Remind>()
 
+    var shared: Boolean = false
+
     fun restore(): Bookmark {
         this.deleted = false
         this.deleteTime = null
@@ -94,6 +96,10 @@ class Bookmark(
     fun updateBookmark(title: String, description: String) {
         this.title = title
         this.description = description
+    }
+
+    fun changeSharedTrue() {
+        this.shared = true
     }
 
     fun deletedByFolder() {

--- a/src/main/kotlin/com/yapp/web2/domain/bookmark/repository/BookmarkRepository.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/bookmark/repository/BookmarkRepository.kt
@@ -14,6 +14,8 @@ interface BookmarkRepository : MongoRepository<Bookmark, String> {
 
     fun findAllByFolderId(folderId: Long): List<Bookmark>
 
+    fun findAllByFolderId(folderIdList: List<Long?>): List<Bookmark>
+
     fun findAllByFolderIdAndDeleteTimeIsNullAndRemindTimeIsNotNull(folderId: Long, pageable: Pageable): Page<Bookmark>
 
     fun findAllByFolderIdAndDeletedIsFalse(folderId: Long, pageable: Pageable): Page<Bookmark>

--- a/src/main/kotlin/com/yapp/web2/domain/bookmark/service/BookmarkService.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/bookmark/service/BookmarkService.kt
@@ -52,7 +52,10 @@ class BookmarkService(
         val bookmarkList = bookmarkRepository.findAllByFolderId(folderId)
 
         for (savedBookmark in bookmarkList) {
-            if (savedBookmark.link == bookmark.link) throw SameBookmarkException()
+            if (savedBookmark.link == bookmark.link) {
+                if(savedBookmark.deleted) throw RuntimeException("휴지통에 존재하는 북마크와 url이 동일합니다!")
+                throw SameBookmarkException()
+            }
         }
     }
 

--- a/src/main/kotlin/com/yapp/web2/domain/bookmark/service/SharedBookmarkService.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/bookmark/service/SharedBookmarkService.kt
@@ -2,9 +2,9 @@ package com.yapp.web2.domain.bookmark.service
 
 import com.yapp.web2.domain.account.entity.Account
 import com.yapp.web2.domain.bookmark.BookmarkDto
-import com.yapp.web2.domain.bookmark.entity.BookmarkInterface
-import com.yapp.web2.domain.bookmark.entity.SharedBookmark
-import com.yapp.web2.domain.bookmark.repository.BookmarkInterfaceRepository
+import com.yapp.web2.domain.bookmark.entity.Bookmark
+import com.yapp.web2.domain.bookmark.entity.Remind
+import com.yapp.web2.domain.bookmark.repository.BookmarkRepository
 import com.yapp.web2.domain.folder.entity.Authority
 import com.yapp.web2.domain.folder.entity.Folder
 import com.yapp.web2.domain.folder.repository.FolderRepository
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 @Transactional
 class SharedBookmarkService(
-    private val bookmarkInterfaceRepository: BookmarkInterfaceRepository,
+    private val bookmarkRepository: BookmarkRepository,
     private val folderRepository: FolderRepository,
     private val jwtProvider: JwtProvider
 ) {
@@ -35,18 +35,18 @@ class SharedBookmarkService(
         throw NoPermissionException()
     }
 
-    fun addBookmark(token: String, folderId: Long, bookmarkDto: BookmarkDto.AddBookmarkDto): BookmarkInterface {
+    fun addBookmark(token: String, folderId: Long, bookmarkDto: BookmarkDto.AddBookmarkDto): Bookmark {
         val account = jwtProvider.getAccountFromToken(token)
         checkAuthority(account, folderId)
 
         val folder = checkFolderAbsence(folderId)
-        val bookmark = BookmarkDto.addBookmarkDtoToSharedBookmark(bookmarkDto, account, folder)
+        val bookmark = BookmarkDto.addBookmarkDtoToBookmark(bookmarkDto, account)
 
-        bookmark.changeFolderInfo(folder.id, folder.emoji, folder.name)
+        bookmark.changeFolderInfo(folder)
         checkSameBookmark(bookmark, folderId)
         folder.updateBookmarkCount(1)
 
-        return bookmarkInterfaceRepository.save(bookmark)
+        return bookmarkRepository.save(bookmark)
     }
 
     fun addBookmarkList(token: String, folderId: Long, dto: BookmarkDto.AddBookmarkListDto) {
@@ -59,11 +59,11 @@ class SharedBookmarkService(
         return folderRepository.findFolderById(folderId) ?: throw ObjectNotFoundException()
     }
 
-    fun checkSameBookmark(bookmarkInterface: BookmarkInterface, folderId: Long) {
-        val bookmarkList = bookmarkInterfaceRepository.findAllByFolderId(folderId) ?: throw SameBookmarkException()
+    fun checkSameBookmark(bookmark: Bookmark, folderId: Long) {
+        val bookmarkList = bookmarkRepository.findAllByFolderId(folderId)
 
         for (savedBookmark in bookmarkList) {
-            if (savedBookmark.link == bookmarkInterface.link) throw SameBookmarkException()
+            if (savedBookmark.link == bookmark.link) throw SameBookmarkException()
         }
     }
 
@@ -71,55 +71,53 @@ class SharedBookmarkService(
         val account = jwtProvider.getAccountFromToken(token)
         checkAuthority(account, dto.folderId)
 
-        val bookmarkList = bookmarkInterfaceRepository.findAllById(dto.dotoriIdList)
+        val bookmarkList = bookmarkRepository.findAllById(dto.dotoriIdList)
         val folder = checkFolderAbsence(dto.folderId)
-
-        bookmarkInterfaceRepository.deleteAllByParentBookmarkId(dto.dotoriIdList)
 
         for (bookmark in bookmarkList) {
             bookmark.deleteBookmark()
             folder.updateBookmarkCount(-1)
         }
 
-        bookmarkInterfaceRepository.saveAll(bookmarkList)
+        bookmarkRepository.saveAll(bookmarkList)
     }
 
     fun updateBookmark(token: String, bookmarkId: String, dto: BookmarkDto.UpdateSharedBookmarkDto) {
         val account = jwtProvider.getAccountFromToken(token)
         checkAuthority(account, dto.folderId)
 
-        val bookmark = bookmarkInterfaceRepository.findBookmarkInterfaceById(bookmarkId) ?: throw BookmarkNotFoundException()
+        val toChangeBookmark = bookmarkRepository.findBookmarkById(bookmarkId) ?: throw BookmarkNotFoundException()
 
-        bookmark.updateBookmark(dto.title, dto.description)
-        bookmarkInterfaceRepository.save(bookmark)
-
-        val bookmarkList = bookmarkInterfaceRepository.findAllByParentBookmarkId(bookmarkId)
-        for (b in bookmarkList) b.updateBookmark(dto.title, dto.description)
-
-        bookmarkInterfaceRepository.saveAll(bookmarkList)
+        toChangeBookmark.updateBookmark(dto.title, dto.description)
+        bookmarkRepository.save(toChangeBookmark)
     }
 
     fun moveBookmarkList(token: String, dto: BookmarkDto.MoveBookmarkDto) {
         val account = jwtProvider.getAccountFromToken(token)
         checkAuthority(account, dto.nextFolderId)
-        val bookmarkList = bookmarkInterfaceRepository.findAllById(dto.bookmarkIdList)
+        checkSameRootFolder(dto.folderId, dto.nextFolderId)
+        val bookmarkList = bookmarkRepository.findAllById(dto.bookmarkIdList)
         val folder = folderRepository.findFolderById(dto.nextFolderId) ?: throw FolderNotFoundException()
 
         for (bookmark in bookmarkList) {
-            val sharedBookmark = bookmark as SharedBookmark
-            if (!sharedBookmark.isSameRootFolderId(folder.rootFolderId)) throw NotSameRootFolderException()
-
             deleteBookmarkInfoAtFolder(bookmark)
 
-            sharedBookmark.moveFolder(dto.nextFolderId)
-            sharedBookmark.changeFolderInfo(folder)
+            bookmark.moveFolder(dto.nextFolderId)
+            bookmark.changeFolderInfo(folder)
             folder.updateBookmarkCount(1)
         }
 
-        bookmarkInterfaceRepository.saveAll(bookmarkList)
+        bookmarkRepository.saveAll(bookmarkList)
     }
 
-    fun deleteBookmarkInfoAtFolder(bookmark: SharedBookmark) {
+    fun checkSameRootFolder(beforeFolderId: Long, nextFolderId: Long) {
+        val beforeFolder = folderRepository.findFolderById(beforeFolderId) ?: throw FolderNotFoundException()
+        val nextFolder = folderRepository.findFolderById(nextFolderId) ?: throw FolderNotFoundException()
+
+        if(!beforeFolder.isFolderSameRootFolder(nextFolder)) throw NotSameRootFolderException()
+    }
+
+    fun deleteBookmarkInfoAtFolder(bookmark: Bookmark) {
         bookmark.folderId?.let {
             folderRepository.findFolderById(it)
         }?.run {
@@ -130,23 +128,25 @@ class SharedBookmarkService(
     fun toggleOnRemindBookmark(token: String, bookmarkId: String) {
         val account = jwtProvider.getAccountFromToken(token)
         val bookmark =
-            bookmarkInterfaceRepository.findBookmarkInterfaceById(bookmarkId) ?: throw BookmarkNotFoundException()
-        val copyBookmark = BookmarkInterface.copyBookmark(account, bookmark)
+            bookmarkRepository.findBookmarkById(bookmarkId) ?: throw BookmarkNotFoundException()
+        val folderId = bookmark.folderId ?: throw RuntimeException("폴더에 속해있지 않습니다!")
+        val remind = Remind(account)
 
-        bookmark.remindOn(account.id!!)
+        checkAuthority(account, folderId)
 
-        bookmarkInterfaceRepository.save(copyBookmark)
-        bookmarkInterfaceRepository.save(bookmark)
+        bookmark.remindOn(remind)
+        bookmarkRepository.save(bookmark)
     }
 
     fun toggleOffRemindBookmark(token: String, bookmarkId: String) {
         val account = jwtProvider.getAccountFromToken(token)
         val bookmark =
-            bookmarkInterfaceRepository.findBookmarkInterfaceById(bookmarkId) ?: throw BookmarkNotFoundException()
+            bookmarkRepository.findBookmarkById(bookmarkId) ?: throw BookmarkNotFoundException()
+        val folderId = bookmark.folderId ?: throw RuntimeException("폴더에 속해있지 않습니다!")
+        checkAuthority(account, folderId)
 
-        bookmarkInterfaceRepository.deleteByParentBookmarkIdAndUserId(bookmarkId, account.id!!)
         bookmark.remindOff(account.id!!)
 
-        bookmarkInterfaceRepository.save(bookmark)
+        bookmarkRepository.save(bookmark)
     }
 }

--- a/src/main/kotlin/com/yapp/web2/domain/folder/controller/FolderController.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/folder/controller/FolderController.kt
@@ -113,10 +113,16 @@ class FolderController(
     }
 
     // TODO: 2022/06/22 유저 정보 확인
-    @ApiOperation(value = "암호화된 폴더 ID 조회 API")
+    @ApiOperation(value = "폴더 토큰 발급 API")
     @GetMapping("encrypt/{folderId}")
     fun getEncryptFolderId(@PathVariable folderId: Long): ResponseEntity<FolderTokenDto> {
         return ResponseEntity.status(HttpStatus.OK).body(folderService.encryptFolderId(folderId))
+    }
+
+    @ApiOperation(value = "초대를 위한 폴더 토큰 발급 API")
+    @GetMapping("invite/{folderId}")
+    fun getFolderInvitationToken(@PathVariable folderId: Long): ResponseEntity<FolderTokenDto> {
+        return ResponseEntity.status(HttpStatus.OK).body(folderService.createFolderInvitationToken(folderId))
     }
 
     @ApiOperation(value = "보관함에 속한 유저 리스트 조회 API")

--- a/src/main/kotlin/com/yapp/web2/domain/folder/entity/Folder.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/folder/entity/Folder.kt
@@ -174,4 +174,10 @@ class Folder(
     fun updateBookmarkCount(count: Int) {
         this.bookmarkCount += count
     }
+
+    fun setRootFolder(folder: Folder) {
+        folder.rootFolderId?.let {
+            this.rootFolderId = it
+        } ?: let { this.rootFolderId = folder.id }
+    }
 }

--- a/src/main/kotlin/com/yapp/web2/domain/folder/entity/Folder.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/folder/entity/Folder.kt
@@ -183,4 +183,9 @@ class Folder(
         if(parentFolder == null) return true
         return false
     }
+
+    fun isFolderSameRootFolder(folder: Folder): Boolean {
+        if(folder.rootFolderId == this.rootFolderId) return true
+        return false
+    }
 }

--- a/src/main/kotlin/com/yapp/web2/domain/folder/entity/Folder.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/folder/entity/Folder.kt
@@ -175,9 +175,12 @@ class Folder(
         this.bookmarkCount += count
     }
 
-    fun setRootFolder(folder: Folder) {
-        folder.rootFolderId?.let {
-            this.rootFolderId = it
-        } ?: let { this.rootFolderId = folder.id }
+    fun folderToShared(rootFolderId: Long) {
+        this.rootFolderId = rootFolderId
+    }
+
+    fun isRootFolder(): Boolean {
+        if(parentFolder == null) return true
+        return false
     }
 }

--- a/src/main/kotlin/com/yapp/web2/domain/folder/service/FolderService.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/folder/service/FolderService.kt
@@ -324,6 +324,42 @@ class FolderService(
         return childList
     }
 
+    fun createFolderInvitationToken(rootFolderId: Long): FolderTokenDto {
+        //그냥 재귀를 돌면서 Folder 리스트들을 다 받고, 그 후에 폴더들에 rootFolder 추가, 북마크 shared 변경 하면 되지 않을까? 굳이 재귀?
+        val folder = folderRepository.findFolderById(rootFolderId) ?: throw FolderNotFoundException()
+        if(!folder.isRootFolder()) throw RuntimeException("보관함이 아닙니다! 공유를 할 수 없습니다.")
+
+        // 하위 폴더들 모두 rootFolderId 추가해주기
+        val sharedFolderIdList = folderToShared(folder, rootFolderId)
+
+        // 하위 북마크들 모두 shared가 true인 상태로 변경해주기
+        changeBookmarkToShared(sharedFolderIdList)
+
+        // 토큰 발급
+        return FolderTokenDto(jwtProvider.createFolderToken(rootFolderId))
+    }
+
+    private fun changeBookmarkToShared(sharedFolderIdList: List<Long?>) {
+        val bookmarkList = bookmarkRepository.findAllByFolderId(sharedFolderIdList)
+
+        for (bookmark in bookmarkList)
+            bookmark.changeSharedTrue()
+    }
+
+    private fun folderToShared(folder: Folder, rootFolderId: Long): List<Long?> {
+        val folderIdList = mutableListOf<Long?>()
+        folder.folderToShared(rootFolderId)
+        folderIdList.add(folder.id)
+
+        folder.children?.let {
+            for (child in it) {
+                folderIdList.addAll(folderToShared(child, rootFolderId))
+            }
+        }
+
+        return folderIdList
+    }
+
     fun encryptFolderId(folderId: Long): FolderTokenDto {
         val folder = folderRepository.findFolderById(folderId) ?: throw FolderNotFoundException()
         return FolderTokenDto(jwtProvider.createFolderToken(folderId = folder.id!!))

--- a/src/test/kotlin/com/yapp/web2/domain/bookmark/service/SharedBookmarkServiceTest.kt
+++ b/src/test/kotlin/com/yapp/web2/domain/bookmark/service/SharedBookmarkServiceTest.kt
@@ -92,7 +92,7 @@ internal class SharedBookmarkServiceTest {
 
         // then
         assertAll(
-            {Assertions.assertThat(actual.link).isEqualTo(testDto.link)},
+            {Assertions.assertThat(actual.link).isEqualTo(testDto.url)},
             {Assertions.assertThat(actual.title).isEqualTo(testDto.title)},
             {Assertions.assertThat(actual.image).isEqualTo(testDto.image)},
             {Assertions.assertThat(actual.image).isEqualTo(testDto.image)},


### PR DESCRIPTION
### 개요
- 공유 보관함을 나가는 API 추가
- 북마크 추가할 때, link이던 이름을 url로 수정
- 보관함에 초대할 때, 로직 수정
- 북마크가 추가될 때, 휴지통에 존재하는 북마크 확인 로직 추가

### 작업사항
- folderIdList로 북마크를 조회하는 메소드 추가
- folder를 shared인 상태로 변경하는 로직 추가
- folder가 보관함인지 확인하는 로직 추가
- 보관함 초대 API 추가
- folderIdList로 북마크를 조회하는 메소드 추가
- folder를 shared인 상태로 변경하는 로직 추가
- folder가 보관함인지 확인하는 로직 추가

----

+ 익스텐션 추가 API 이슈같은 경우는 link -> url로 수정하는 걸로 해결
+ 리마인드 API같은 경우는 /remind uri에서 /remindOn, /remindOff 로 변경
+ 도토리함 추가 이슈 같은 경우는 "휴지통에 존재하는 북마크와 url이 동일합니다!" 메시지 던지도록 리펙토링
+ 도토리 삭제같은 경우, bookmark entity가 동일하지 않았음으로 인한 문제이므로 서버 적용 후 테스트 예정
+ 공유 보관함에 초대 링크를 만드는 경우에 폴더의 rootFolderId를 추가하고, bookmark들에 shared를 true로 변경하는 로직 추가