### PR TITLE
[#168] 공유 관련 수정

### DIFF
--- a/src/main/kotlin/com/yapp/web2/domain/account/entity/Account.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/account/entity/Account.kt
@@ -43,34 +43,6 @@ class Account(
         const val BASIC_IMAGE_URL: String = "https://yapp-bucket-test.s3.ap-northeast-2.amazonaws.com/basicImage.png"
     }
 
-    constructor(email: String, password: String) : this(email) {
-        this.password = password
-    }
-
-    constructor(email: String, encryptPassword: String, fcmToken: String, name: String) : this(email) {
-        this.password = encryptPassword
-        this.fcmToken = fcmToken
-        this.name = name
-    }
-
-    constructor(email: String, image: String, nickname: String, socialType: String, fcmToken: String) : this(email) {
-        this.image = image
-        this.name = nickname
-        this.socialType = socialType
-        this.fcmToken = fcmToken
-    }
-
-    fun addAccountFolder(accountFolder: AccountFolder) {
-        this.accountFolderList.add(accountFolder)
-    }
-
-    @Transactional
-    fun isInsideAccountFolder(accountFolder: AccountFolder): Boolean {
-        accountFolderList.forEach {
-            if (it.folder.id == accountFolder.folder.id) return true
-        }
-        return false
-    }
 
     @Column(nullable = true)
     var password: String? = null
@@ -101,6 +73,35 @@ class Account(
 
     @OneToMany(mappedBy = "account", cascade = [CascadeType.ALL])
     var accountFolderList: MutableList<AccountFolder> = mutableListOf()
+
+    constructor(email: String, password: String) : this(email) {
+        this.password = password
+    }
+
+    constructor(email: String, encryptPassword: String, fcmToken: String, name: String) : this(email) {
+        this.password = encryptPassword
+        this.fcmToken = fcmToken
+        this.name = name
+    }
+
+    constructor(email: String, image: String, nickname: String, socialType: String, fcmToken: String) : this(email) {
+        this.image = image
+        this.name = nickname
+        this.socialType = socialType
+        this.fcmToken = fcmToken
+    }
+
+    fun addAccountFolder(accountFolder: AccountFolder) {
+        this.accountFolderList.add(accountFolder)
+    }
+
+    @Transactional
+    fun isInsideAccountFolder(accountFolder: AccountFolder): Boolean {
+        accountFolderList.forEach {
+            if (it.folder.id == accountFolder.folder.id) return true
+        }
+        return false
+    }
 
     @ApiModel(description = "소셜로그인 DTO")
     class AccountProfile(

--- a/src/main/kotlin/com/yapp/web2/domain/account/entity/Account.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/account/entity/Account.kt
@@ -71,7 +71,7 @@ class Account(
     @Column
     var deleted: Boolean = false
 
-    @OneToMany(mappedBy = "account", cascade = [CascadeType.ALL])
+    @OneToMany(mappedBy = "account", cascade = [CascadeType.ALL], orphanRemoval = true)
     var accountFolderList: MutableList<AccountFolder> = mutableListOf()
 
     constructor(email: String, password: String) : this(email) {
@@ -169,11 +169,9 @@ class Account(
     )
 
     fun removeFolderInAccountFolder(folder: Folder) {
-        for(af in this.accountFolderList)
-            if (af.folder == folder) {
-                accountFolderList.remove(af)
-                return
-            }
+        this.accountFolderList.let {
+            it.removeIf { af -> af.folder == folder }
+        }
     }
 
     fun softDeleteAccount() {

--- a/src/main/kotlin/com/yapp/web2/domain/folder/entity/AccountFolder.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/folder/entity/AccountFolder.kt
@@ -21,13 +21,13 @@ class AccountFolder(
     var folder: Folder
 ) {
 
-    fun changeAuthority(authority: Authority) {
-        this.authority = authority
-    }
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long? = null
 
     var authority: Authority = Authority.NONE
+
+    fun changeAuthority(authority: Authority) {
+        this.authority = authority
+    }
 }

--- a/src/main/kotlin/com/yapp/web2/domain/folder/entity/Folder.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/folder/entity/Folder.kt
@@ -35,7 +35,7 @@ class Folder(
     @JsonManagedReference
     var children: MutableList<Folder>? = mutableListOf()
 
-    @OneToMany(mappedBy = "folder", cascade = [CascadeType.ALL])
+    @OneToMany(mappedBy = "folder", cascade = [CascadeType.ALL], orphanRemoval = true)
     var folders: MutableList<AccountFolder>? = mutableListOf()
 
     // TODO: 2022/05/06 공유 북마크인지 확인하기 위해서 추가한 컬럼

--- a/src/main/kotlin/com/yapp/web2/domain/folder/entity/Folder.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/folder/entity/Folder.kt
@@ -35,6 +35,7 @@ class Folder(
     @JsonManagedReference
     var children: MutableList<Folder>? = mutableListOf()
 
+    // TODO: 2022/08/14 cascadeType.REMOVE도 포함되어 있기 때문에, delete문이 실행된다고함. 이를 빼고 진행할 수 있도록 그리고 orphanRemoval만 사용했을 때 좋은 이유를 확실히 알것
     @OneToMany(mappedBy = "folder", cascade = [CascadeType.ALL], orphanRemoval = true)
     var folders: MutableList<AccountFolder>? = mutableListOf()
 

--- a/src/main/kotlin/com/yapp/web2/domain/folder/service/FolderService.kt
+++ b/src/main/kotlin/com/yapp/web2/domain/folder/service/FolderService.kt
@@ -330,7 +330,7 @@ class FolderService(
         if(!folder.isRootFolder()) throw RuntimeException("보관함이 아닙니다! 공유를 할 수 없습니다.")
 
         // 하위 폴더들 모두 rootFolderId 추가해주기
-        val sharedFolderIdList = folderToShared(folder, rootFolderId)
+        val sharedFolderIdList = changeFolderToShared(folder, rootFolderId)
 
         // 하위 북마크들 모두 shared가 true인 상태로 변경해주기
         changeBookmarkToShared(sharedFolderIdList)
@@ -346,14 +346,14 @@ class FolderService(
             bookmark.changeSharedTrue()
     }
 
-    private fun folderToShared(folder: Folder, rootFolderId: Long): List<Long?> {
+    private fun changeFolderToShared(folder: Folder, rootFolderId: Long): List<Long?> {
         val folderIdList = mutableListOf<Long?>()
         folder.folderToShared(rootFolderId)
         folderIdList.add(folder.id)
 
         folder.children?.let {
             for (child in it) {
-                folderIdList.addAll(folderToShared(child, rootFolderId))
+                folderIdList.addAll(changeFolderToShared(child, rootFolderId))
             }
         }
 

--- a/src/test/kotlin/com/yapp/web2/domain/folder/service/FolderServiceTest.kt
+++ b/src/test/kotlin/com/yapp/web2/domain/folder/service/FolderServiceTest.kt
@@ -475,12 +475,12 @@ internal open class FolderServiceTest {
     @Test
     fun `폴더의 이름을 조회한다`() {
         // given
-        val expected = FolderDto.FolderNameDto("Folder")
+        val expected = FolderDto.FolderInfoDto("Folder", "test")
         every { folderRepository.findFolderById(any()) } returns folder
-        every { aeS256Util.decrypt(any()) } returns "1"
+        every { jwtProvider.getIdFromToken(any()) } returns 1
 
         // when
-        val actual = folderService.getFolderName("token")
+        val actual = folderService.getFolderInfo("token")
 
         // then
         assertThat(actual.name).isEqualTo(expected.name)
@@ -490,10 +490,10 @@ internal open class FolderServiceTest {
     fun `폴더 이름 조회 시 폴더가 존재하지 않으면 예외가 발생한다`() {
         // given
         every { folderRepository.findFolderById(any()) } returns null
-        every { aeS256Util.decrypt(any()) } returns "1"
+        every { jwtProvider.getIdFromToken(any()) } returns 1
 
         // then
-        assertThrows<FolderNotFoundException> { folderService.getFolderName("token") }
+        assertThrows<FolderNotFoundException> { folderService.getFolderInfo("token") }
     }
 
     private fun printJson(actual: Any) {


### PR DESCRIPTION
### 개요
- 리팩토링 사항 작업
- 보관함 초대, 보관함 탈퇴 로직 수정

### 작업사항
- account, folder 리팩토링
- folderDto 명 변경
- 보관함 탈퇴를 위하여 orphanRemoval 상태 true로 변경.

+) cascadeType.ALL vs orphanRemoval = true (manyToMany 연관관계일 때!, 하지만 우리는 ManyToMany를 풀어서 작업했기 때문에 상관이 있는지 없는지 확인해야함.)

- todo: cascadeType.ALL에는 cascadeType.REMOVE가 포함되어 있음.
- cascadeType.REMOVE같은 경우에는 부모에서 자식들에게 조건에 맞는 자식을 찾기위한 propagation이 진행됨 -> 후에 update를 통하여 조건에 맞는 accountFolder의 id를 null로 만든다.
- orphanRemoval = true 같은 경우에는 조인테이블의 자식 행에만 delete를 실행하기 때문에 불필요한 작업이 줄어든다. -> delete문을 한번만 실행.
